### PR TITLE
Fix toolbarbutton styling

### DIFF
--- a/chrome/content/browser.xul
+++ b/chrome/content/browser.xul
@@ -63,7 +63,7 @@
 	<toolbarpalette id="BrowserToolbarPalette">
 		<toolbarbutton id="leechblock-toolbar-button" type="menu"
 			class="toolbarbutton-1 chromeclass-toolbar-additional"
-			label="&leechblock;" tooltiptext="&leechblock;" orient="horizontal">
+			label="&leechblock;" tooltiptext="&leechblock;">
 			<menupopup id="leechblock-toolbar-menupopup"
 				oncommand="LeechBlock.addSiteToSet(event.target, document.commandDispatcher.focusedWindow);"
 				onpopupshowing="LeechBlock.prepareMenu(event.target, document.commandDispatcher.focusedWindow);">


### PR DESCRIPTION
Horizontal orientation breaks styling in popup menu.
